### PR TITLE
Fixes the "InsecurePlatformWarning"

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,11 @@ import json
 import os
 import requests
 import sys
+import warnings
 from tqdm import tqdm
+
+warnings.filterwarnings("ignore")
+
 
 class InstagramScraper:
 


### PR DESCRIPTION
When I run it, I keep getting:

    /usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
      InsecurePlatformWarning


This is a harmless warning that I've dealt with in the past. I would fix it, but not for a scraper. This commit just hides it.

Look it over and tell me if there's anything that I need to change.