### PR TITLE
Two proposed options

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,4 +6,5 @@ Authors
 - Charlie Gorichanaz ([@CNG](https://github.com/CNG))
 - Jacob Lukose ([@jacoblukose](https://github.com/jacoblukose))
 - Nace Oroz ([@orkaa](https://github.com/orkaa))
+- Leif Sawyer ([@akhepcat](https://github.com/akhepcat))
 [home]: README.md

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -118,7 +118,7 @@ class InstagramScraper(object):
                     iter = 0
                     for item in tqdm.tqdm(stories, desc='Searching {0} for stories'.format(username), unit=" media", disable=self.quiet):
                         iter = iter + 1
-                        if ( self.max <> 0 and iter >= self.max ):
+                        if ( self.max != 0 and iter >= self.max ):
                             break
                         else:
                             future = executor.submit(self.download, item, dst)
@@ -129,7 +129,7 @@ class InstagramScraper(object):
             for item in tqdm.tqdm(self.media_gen(username), desc='Searching {0} for posts'.format(username), 
                                 unit=' media', disable=self.quiet):
                 iter = iter + 1
-                if ( self.max <> 0 and iter >= self.max ):
+                if ( self.max != 0 and iter >= self.max ):
                     break
                 else:
                     future = executor.submit(self.download, item, dst)

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -22,7 +22,7 @@ class InstagramScraper(object):
 
     """InstagramScraper scrapes and downloads an instagram user's photos and videos"""
 
-    def __init__(self, usernames, login_user=None, login_pass=None, dst=None, quiet=False):
+    def __init__(self, usernames, quiet, login_user=None, login_pass=None, dst=None):
         self.usernames = usernames if isinstance(usernames, list) else [usernames]
         self.login_user = login_user
         self.login_pass = login_pass
@@ -266,6 +266,7 @@ def main():
     parser.add_argument('--login_user', '-u', help='Instagram login user')
     parser.add_argument('--login_pass', '-p', help='Instagram login password')
     parser.add_argument('--filename', '-f', help='Path to a file containing a list of users to scrape')
+    parser.add_argument('--quiet', '-q', help='Be quiet while scraping')
 
     args = parser.parse_args()
 
@@ -279,15 +280,18 @@ def main():
     elif args.username and args.filename:
         parser.print_help()
         raise ValueError('Must provide only one of the following: username(s) OR a filename containing username(s)')
-
     usernames = []
+
+    quiet = False
+    if args.quiet:
+        quiet = True
 
     if args.filename:
         usernames = InstagramScraper.parse_file_usernames(args.filename)
     else:
         usernames = InstagramScraper.parse_str_usernames(','.join(args.username))
 
-    scraper = InstagramScraper(usernames, args.login_user, args.login_pass, args.destination)
+    scraper = InstagramScraper(usernames, quiet, args.login_user, args.login_pass, args.destination )
     scraper.scrape()
 
 if __name__ == '__main__':

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -22,7 +22,7 @@ class InstagramScraper(object):
 
     """InstagramScraper scrapes and downloads an instagram user's photos and videos"""
 
-    def __init__(self, usernames, max, login_user=None, login_pass=None, dst=None):
+    def __init__(self, usernames, quiet, max, login_user=None, login_pass=None, dst=None):
         self.usernames = usernames if isinstance(usernames, list) else [usernames]
         self.login_user = login_user
         self.login_pass = login_pass
@@ -278,6 +278,7 @@ def main():
     parser.add_argument('--login_user', '-u', help='Instagram login user')
     parser.add_argument('--login_pass', '-p', help='Instagram login password')
     parser.add_argument('--filename', '-f', help='Path to a file containing a list of users to scrape')
+    parser.add_argument('--quiet', '-q', help='Be quiet while scraping')
     parser.add_argument('--maximum', '-m', help='Maximum number of items to scrape')
 
     args = parser.parse_args()
@@ -300,12 +301,16 @@ def main():
         except ValueError:
             max = 0
 
+    quiet = False
+    if args.quiet:
+        quiet = True
+
     if args.filename:
         usernames = InstagramScraper.parse_file_usernames(args.filename)
     else:
         usernames = InstagramScraper.parse_str_usernames(','.join(args.username))
 
-    scraper = InstagramScraper(usernames, max, args.login_user, args.login_pass, args.destination )
+    scraper = InstagramScraper(usernames, quiet, max, args.login_user, args.login_pass, args.destination )
     scraper.scrape()
 
 if __name__ == '__main__':

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -22,11 +22,11 @@ class InstagramScraper(object):
 
     """InstagramScraper scrapes and downloads an instagram user's photos and videos"""
 
-    def __init__(self, usernames, quiet, max, login_user=None, login_pass=None, dst=None):
+    def __init__(self, usernames, login_user=None, login_pass=None, dst=None, quiet=False, max=0):
         self.usernames = usernames if isinstance(usernames, list) else [usernames]
         self.login_user = login_user
         self.login_pass = login_pass
-        self.max = 0 if max is None else max
+        self.max = max
         self.dst = './' if dst is None else dst
 
         # Controls the graphical output of tqdm
@@ -278,8 +278,8 @@ def main():
     parser.add_argument('--login_user', '-u', help='Instagram login user')
     parser.add_argument('--login_pass', '-p', help='Instagram login password')
     parser.add_argument('--filename', '-f', help='Path to a file containing a list of users to scrape')
-    parser.add_argument('--quiet', '-q', help='Be quiet while scraping')
-    parser.add_argument('--maximum', '-m', help='Maximum number of items to scrape')
+    parser.add_argument('--quiet', '-q', action='store_true', help='Be quiet while scraping')
+    parser.add_argument('--maximum', '-m', type=int, default=0, help='Maximum number of items to scrape')
 
     args = parser.parse_args()
 
@@ -295,22 +295,12 @@ def main():
         raise ValueError('Must provide only one of the following: username(s) OR a filename containing username(s)')
     usernames = []
 
-    if (args.maximum and not (args.maximum is None)):
-        try:
-            max = int(args.maximum)
-        except ValueError:
-            max = 0
-
-    quiet = False
-    if args.quiet:
-        quiet = True
-
     if args.filename:
         usernames = InstagramScraper.parse_file_usernames(args.filename)
     else:
         usernames = InstagramScraper.parse_str_usernames(','.join(args.username))
 
-    scraper = InstagramScraper(usernames, quiet, max, args.login_user, args.login_pass, args.destination )
+    scraper = InstagramScraper(usernames, args.login_user, args.login_pass, args.destination, args.quiet, args.maximum )
     scraper.scrape()
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've extended the functionality just a bit with this merge request.

1)  i've exposed the 'quiet' functionality, so that this is much less noisy in a crontab.

2) i've added a 'maximum' option, so that you're never attempting to scrape more than 'max' items per subject.   This is -extremely- useful for users that have a large number of media entries - perform a full scrape initially to 'prime' your local cache, and then set the max to something much lower (say, 25) and perform a daily scrape to keep up-to-date.

I've got three different commit levels in my fork that expose the options separately, or the final commit which merges both together (as proposed)