### PR TITLE
app: Allow reading arguments from file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ instagram-scraper is written and maintained by Richard Arcega, along with the fo
 - Dave Bush ([@corymb](https://github.com/corymb))
 - Dillon Newell ([@DillonN](https://github.com/DillonN))
 - Daniel M. Capella ([@polyzen](https://github.com/polyzen))
+- Carl Helmertz ([@chelmertz](https://github.com/chelmertz))

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -9,6 +9,7 @@ import json
 import logging.config
 import os
 import re
+import textwrap
 import time
 import warnings
 
@@ -475,7 +476,23 @@ class InstagramScraper(object):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="instagram-scraper scrapes and downloads an instagram user's photos and videos.")
+        description="instagram-scraper scrapes and downloads an instagram user's photos and videos.",
+        epilog=textwrap.dedent("""
+        You can hide your credentials from the history, by reading your
+        username from a local file:
+
+        $ instagram-scraper @insta_args.txt user_to_scrape
+
+        with insta_args.txt looking like this:
+        -u=my_username
+        -p=my_password
+
+        You can add all arguments you want to that file, just remember to have
+        one argument per line.
+
+        """),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        fromfile_prefix_chars='@')
 
     parser.add_argument('username', help='Instagram user(s) to scrape', nargs='*')
     parser.add_argument('--destination', '-d', default='./', help='Download destination')


### PR DESCRIPTION
Only allowing the user to pass credentials through command line
arguments will leave traces of the credentials in the user's history. We
can stop that from happening in two ways that comes to mind:

- put the credentials in the environment, or
- put the credentials in a file

Modifying the environment is probably one step less user friendly, since
it's easiest to modify the environment variables for all of the session,
and now every program gets access to your environment.

If you instead put the credentials in a file, Python's argparse already
has support for that out of the box. It also enables saving sets of
arguments into different files, if that's a wanted use case.

There is also a hint about referring to a file in the help text, which
required a small modification for rendering newlines properly.

Signed-off-by: Carl Helmertz <helmertz@gmail.com>