### PR TITLE
Fixing a NoneType check that was missing in _get_nodes()

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -274,11 +274,10 @@ class InstagramScraper(object):
             if node['is_video']:
                 details = self.__get_media_details(node['shortcode'])
 
-                if details:
+                if details and details is not None:
                     node['urls'] = [details['video_url']]
-
-                if self.include_location:
-                    node['location'] = details.get('location')
+                    if self.include_location:
+                        node['location'] = details.get('location')
 
                 self.extract_tags(node)
             else:


### PR DESCRIPTION
A missing NoneType check was causing the code to crash, and throw a:
AttributeError: 'NoneType' object has no attribute 'get'