### PR TITLE
Add ability to download only images or videos from story

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ OPTIONS
                       set.
 
 --media-types -t    Specify media types to scrape. Enter as space separated values. 
-                    Valid values are image, video, story, or none. Stories require
-                    a --login-user and --login-pass to be defined.
+                    Valid values are image, video, story (story-image & story-video),
+                    or none. Stories require a --login-user and --login-pass to be defined.
 
 --latest            Scrape only new media since the last scrape. Uses the last modified
                     time of the latest media item in the destination directory to compare.


### PR DESCRIPTION
This new feature keeps backwards compatibility by adding two new media types:
'story-images' and 'story-videos'. The old option of just 'story' will
represent both 'story-images' and 'story-videos'.

In addition, media from stories also adheres to the `is_new_media` check.