### PR TITLE
removes directory not found error when saving only metadata

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -1034,6 +1034,9 @@ class InstagramScraper(object):
     @staticmethod
     def save_json(data, dst='./'):
         """Saves the data to a json file."""
+        if not os.path.exists(os.path.dirname(dst)):
+            os.makedirs(os.path.dirname(dst))
+            
         if data:
             with open(dst, 'wb') as f:
                 json.dump(data, codecs.getwriter('utf-8')(f), indent=4, sort_keys=True, ensure_ascii=False)


### PR DESCRIPTION
Current build failing on Mac OS when running `-t none --media-metadata` as json.dump() will not create parent directories, and the destination parent directory for the JSON file is only created when downloading media. 