### PR TITLE
Query Followed Profiles

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,3 +17,4 @@ instagram-scraper is written and maintained by Richard Arcega, along with the fo
 - Steve Schmidt ([@stvschmdt](https://github.com/stvschmdt))
 - John Pimental ([@Emalton](https://github.com/Emalton))
 - kcayut ([@kcayut](https://github.com/kcayut))
+- Brian Lambrigger ([@lambriggerbrian](https://github.com/lambriggerbrian))

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ OPTIONS
 
 --login-pass  -p    Instagram login password.
 
+--followings-input  Use profiles followed by login-user as input
+
+--followings-output Output profiles from --followings-input to file
+
 --filename    -f    Path to a file containing a list of users to scrape.
 
 --destination -d    Specify the download destination. By default, media will 

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -1201,8 +1201,7 @@ def main():
     parser.add_argument('--login-pass', '--login_pass', '-p', default=None, help='Instagram login password', required=True)
     parser.add_argument('--followings-input', '--followings_input', action='store_true', default=False,
                         help='Compile list of profiles followed by login-user to use as input')
-    parser.add_argument('--followings-output', '--followings_output', default='profiles.txt',
-                        help='Output followings-input to file in destination')
+    parser.add_argument('--followings-output', '--followings_output', help='Output followings-input to file in destination')
     parser.add_argument('--filename', '-f', help='Path to a file containing a list of users to scrape')
     parser.add_argument('--quiet', '-q', default=False, action='store_true', help='Be quiet while scraping')
     parser.add_argument('--maximum', '-m', type=int, default=0, help='Maximum number of items to scrape')

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -470,7 +470,10 @@ class InstagramScraper(object):
                     self.set_last_scraped_timestamp(value, greatest_timestamp)
 
                 if (self.media_metadata or self.comments or self.include_location) and self.posts:
-                    self.save_json(self.posts, '{0}/{1}.json'.format(dst, value))
+                    if self.latest:
+                        self.merge_json(self.posts, '{0}/{1}.json'.format(dst, value))
+                    else:
+                        self.save_json(self.posts, '{0}/{1}.json'.format(dst, value))
         finally:
             self.quit = True
 
@@ -628,7 +631,10 @@ class InstagramScraper(object):
                         self.set_last_scraped_timestamp(username, greatest_timestamp)
 
                     if (self.media_metadata or self.comments or self.include_location) and self.posts:
-                        self.save_json(self.posts, '{0}/{1}.json'.format(dst, username))
+                        if self.latest:
+                            self.merge_json(self.posts, '{0}/{1}.json'.format(dst, username))
+                        else:
+                            self.save_json(self.posts, '{0}/{1}.json'.format(dst, username))
                 except ValueError:
                     self.logger.error("Unable to scrape user - %s" % username)
         finally:
@@ -1061,6 +1067,16 @@ class InstagramScraper(object):
                 place['location']['lat'],
                 place['location']['lng']
             ))
+
+    def merge_json(self, data, dst='./'):
+        if not os.path.exists(dst):
+            self.save_json(data, dst)
+
+        if data:
+            merged = data
+            with open(dst, 'r') as f:
+                merged += json.load(f)
+            self.save_json(merged, dst)
 
     @staticmethod
     def save_json(data, dst='./'):

--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -81,7 +81,7 @@ class InstagramScraper(object):
     def __init__(self, **kwargs):
         default_attr = dict(username='', usernames=[], filename=None,
                             login_user=None, login_pass=None,
-                            query_followings=False, followings_output='profiles.txt',
+                            followings_input=False, followings_output='profiles.txt',
                             destination='./', retain_username=False, interactive=False,
                             quiet=False, maximum=0, media_metadata=False, latest=False,
                             latest_stamps=False,
@@ -1183,10 +1183,10 @@ def main():
     parser.add_argument('--destination', '-d', default='./', help='Download destination')
     parser.add_argument('--login-user', '--login_user', '-u', default=None, help='Instagram login user', required=True)
     parser.add_argument('--login-pass', '--login_pass', '-p', default=None, help='Instagram login password', required=True)
-    parser.add_argument('--query-followings', '--query_followings', action='store_true', default=False,
+    parser.add_argument('--followings-input', '--followings_input', action='store_true', default=False,
                         help='Compile list of profiles followed by login-user to use as input')
     parser.add_argument('--followings-output', '--followings_output', default='profiles.txt',
-                        help='Output query-followings to file in destination')
+                        help='Output followings-input to file in destination')
     parser.add_argument('--filename', '-f', help='Path to a file containing a list of users to scrape')
     parser.add_argument('--quiet', '-q', default=False, action='store_true', help='Be quiet while scraping')
     parser.add_argument('--maximum', '-m', type=int, default=0, help='Maximum number of items to scrape')
@@ -1219,12 +1219,12 @@ def main():
         parser.print_help()
         raise ValueError('Must provide login user AND password')
 
-    if not args.username and args.filename is None:
+    if not args.username and args.filename is None and not args.followings_input:
         parser.print_help()
-        raise ValueError('Must provide username(s) OR a file containing a list of username(s)')
-    elif args.username and args.filename:
+        raise ValueError('Must provide username(s) OR a file containing a list of username(s) OR pass --followings-input')
+    elif (args.username and args.filename) or (args.username and args.followings_input) or (args.filename and args.followings_input):
         parser.print_help()
-        raise ValueError('Must provide only one of the following: username(s) OR a filename containing username(s)')
+        raise ValueError('Must provide only one of the following: username(s) OR a filename containing username(s) OR --followings-input')
 
     if args.tag and args.location:
         parser.print_help()
@@ -1250,7 +1250,7 @@ def main():
 
     scraper.login()
 
-    if args.query_followings:
+    if args.followings_input:
         scraper.usernames = list(scraper.query_followings_gen(scraper.login_user))
         if args.followings_output:
             with open(scraper.destination+scraper.followings_output, 'w') as file:

--- a/instagram_scraper/constants.py
+++ b/instagram_scraper/constants.py
@@ -13,6 +13,9 @@ LOCATIONS_URL = BASE_URL + 'explore/locations/{0}/?__a=1'
 VIEW_MEDIA_URL = BASE_URL + 'p/{0}/?__a=1'
 SEARCH_URL = BASE_URL + 'web/search/topsearch/?context=blended&query={0}'
 
+QUERY_FOLLOWINGS = BASE_URL + 'graphql/query/?query_hash=c56ee0ae1f89cdbd1c89e2bc6b8f3d18&variables={0}'
+QUERY_FOLLOWINGS_VARS = '{{"id":"{0}","first":50,"after":"{1}"}}'
+
 QUERY_COMMENTS = BASE_URL + 'graphql/query/?query_hash=33ba35852cb50da46f5b5e889df7d159&variables={0}'
 QUERY_COMMENTS_VARS = '{{"shortcode":"{0}","first":50,"after":"{1}"}}'
 


### PR DESCRIPTION
10/9: Adds ability to query the profiles a user follows, and adds option to use login-user's followed as input
- `query_followings_gen` takes a username, then passes the username's ID to `__query_followings`, and collects profiles followed by the username
- `QUERY_FOLLOWINGS` and `QUERY_FOLLOWINGS_PARAMS` constants added to construct related URL's
- `--followings-input` option uses profiles followed by login-user as input (throws error if used with -f or explicit user arguments)
- `--followings-output [arg]` option outputs list compiled from `--followings-input` to file at `destination/arg` (no effect without `--followings-input`)