### PR TITLE
Hotfix for missing rhx_gis key (#377)

### DIFF
--- a/instagram_scraper/app.py
+++ b/instagram_scraper/app.py
@@ -136,7 +136,7 @@ class InstagramScraper(object):
             with open(self.cookiejar, 'rb') as f:
                 self.session.cookies.update(pickle.load(f))
         self.session.cookies.set('ig_pr', '1')
-        self.rhx_gis = None
+        self.rhx_gis = ""
 
         self.cookies = None
         self.authenticated = False
@@ -231,7 +231,7 @@ class InstagramScraper(object):
         self.session.headers.update({'X-CSRFToken': req.cookies['csrftoken']})
 
         self.session.headers = {'user-agent': CHROME_WIN_UA}
-        self.rhx_gis = self.get_shared_data()['rhx_gis']
+        self.rhx_gis = ""
         self.authenticated = True
 
     def authenticate_with_login(self):
@@ -251,7 +251,7 @@ class InstagramScraper(object):
             self.authenticated = True
             self.logged_in = True
             self.session.headers = {'user-agent': CHROME_WIN_UA}
-            self.rhx_gis = self.get_shared_data()['rhx_gis']
+            self.rhx_gis = ""
         else:
             self.logger.error('Login failed for ' + self.login_user)
 
@@ -632,7 +632,7 @@ class InstagramScraper(object):
                     user['edge_owner_to_timeline_media']['edges']:
                         self.logger.info('User {0} is private'.format(username))
 
-                self.rhx_gis = shared_data['rhx_gis']
+                self.rhx_gis = ""
             
                 self.get_profile_pic(dst, executor, future_to_item, user, username)
 


### PR DESCRIPTION
Around May 15 2019, the package suddenly stopped working with the error:
>`KeyError: 'rhx_gis'`
(This error is discussed in Issue #377)

@reliefs implemented a hotfix to their own repo, I am simply copying the changes into a fork of the `instagram-scraper` repo so I can PR it over.